### PR TITLE
add option to turn on/off version check

### DIFF
--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -21,13 +21,15 @@ class CacheManager extends IlluminateCacheManager
         // Extract Plus features from config
         $persistentConnectionId = array_get($config, 'persistent_id');
         $customOptions = array_get($config, 'options', []);
+        $checkVersion = array_get($config, 'check_version', true);
         $saslCredentials = array_filter(array_get($config, 'sasl', []));
 
         $memcached = $this->app['memcached.connector']->connect(
             $config['servers'],
             $persistentConnectionId,
             $customOptions,
-            $saslCredentials
+            $saslCredentials,
+            $checkVersion
         );
 
         return $this->repository(new MemcachedStore($memcached, $prefix));

--- a/src/MemcachedConnector.php
+++ b/src/MemcachedConnector.php
@@ -21,7 +21,8 @@ class MemcachedConnector
      */
     public function connect(
         array $servers, $connectionId = null,
-        array $options = [], array $credentials = []
+        array $options = [], array $credentials = [],
+        $checkVersion = true
     ) {
         $memcached = $this->getMemcached(
             $connectionId, $credentials, $options
@@ -37,8 +38,6 @@ class MemcachedConnector
                 );
             }
         }
-        // some cloud memcached service don't return correct version, so skip version check.
-        $checkVersion = in_array("check_version",$options) ? $options["check_version"] : FALSE;
 
         return $this->validateConnection($memcached, $checkVersion);
     }
@@ -99,7 +98,7 @@ class MemcachedConnector
      * @param  \Memcached  $memcached
      * @return \Memcached
      */
-    protected function validateConnection($memcached, $checkVersion=TRUE)
+    protected function validateConnection($memcached, $checkVersion=true)
     {
         $status = $memcached->getVersion();
 

--- a/src/MemcachedConnector.php
+++ b/src/MemcachedConnector.php
@@ -37,8 +37,10 @@ class MemcachedConnector
                 );
             }
         }
+        // some cloud memcached service don't return correct version, so skip version check.
+        $checkVersion = in_array("check_version",$options) ? $options["check_version"] : FALSE;
 
-        return $this->validateConnection($memcached);
+        return $this->validateConnection($memcached, $checkVersion);
     }
 
     /**
@@ -97,7 +99,7 @@ class MemcachedConnector
      * @param  \Memcached  $memcached
      * @return \Memcached
      */
-    protected function validateConnection($memcached)
+    protected function validateConnection($memcached, $checkVersion=TRUE)
     {
         $status = $memcached->getVersion();
 
@@ -105,7 +107,7 @@ class MemcachedConnector
             throw new RuntimeException('No Memcached servers added.');
         }
 
-        if (in_array('255.255.255', $status) && count(array_unique($status)) === 1) {
+        if ($checkVersion && in_array('255.255.255', $status) && count(array_unique($status)) === 1) {
             throw new RuntimeException('Could not establish Memcached connection.');
         }
 


### PR DESCRIPTION
for some cloud memcached service doesn't return correct version, but function is normal. Add a option  able to skip version check. default version check is enable.